### PR TITLE
Removed BOM marker from gradingform_erubric.php

### DIFF
--- a/lang/el/gradingform_erubric.php
+++ b/lang/el/gradingform_erubric.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify


### PR DESCRIPTION
 Changes to be committed:
	modified:   lang/el/gradingform_erubric.php

lang/el/gradingform_erubric.php had a BOM. It's an invisible character
that is going to get echoed out because it always exists before the
openning PHP tag.

https://www.w3.org/International/questions/qa-byte-order-mark